### PR TITLE
Allow links to be opened in a new tab and bug fixes

### DIFF
--- a/docoloco/models/base.py
+++ b/docoloco/models/base.py
@@ -94,9 +94,10 @@ class DocSet(GObject.Object):
     is_javascript_enabled = True
     icon_files: List[Path] = None
 
-    def __init__(self):
+    def __init__(self, provider_id: str):
         super().__init__()
 
+        self.provider_id = provider_id
         self.keywords: Set[str] = set()
         self.symbol_strings: Dict[str, List] = dict()
         self.symbol_counts: Dict[str, int] = dict()

--- a/docoloco/providers/dash_provider.py
+++ b/docoloco/providers/dash_provider.py
@@ -21,7 +21,7 @@ class DashProvider(DocumentationProvider):
     def load(self):
         for doc_path in self.root_path.iterdir():
             try:
-                doc = DashDocSet(path=doc_path)
+                doc = DashDocSet(provider_id=self.name, path=doc_path)
                 self.docs[doc.name] = doc
             except Exception as e:
                 print(e)
@@ -52,8 +52,8 @@ class DashDocSet(DocSet):
         ZDASH = 2
         INVALID = 3
 
-    def __init__(self, path: Path) -> None:
-        super().__init__()
+    def __init__(self, provider_id: str, path: Path) -> None:
+        super().__init__(provider_id)
         
         self.dir = path
         if not self.dir.exists():

--- a/docoloco/providers/man_provider.py
+++ b/docoloco/providers/man_provider.py
@@ -30,7 +30,7 @@ class ManProvider(DocumentationProvider):
                 parts = line.split("(")
                 name = parts[0].strip()
 
-                doc = ManDocSet(name=name, description=line)
+                doc = ManDocSet(provider_id=self.name, name=name, description=line)
                 self.query_results_model.append(doc)
         else:
             print(error.decode())
@@ -39,8 +39,8 @@ class ManProvider(DocumentationProvider):
 class ManDocSet(DocSet):
     __gtype_name__ = "ManDocSet"
 
-    def __init__(self, name: str, description: str):
-        super().__init__()
+    def __init__(self, provider_id: str, name: str, description: str):
+        super().__init__(provider_id)
 
         self.name = self.title = name
         self.description = description

--- a/docoloco/window/doc_page.py
+++ b/docoloco/window/doc_page.py
@@ -62,8 +62,8 @@ class DocPage(Adw.Bin):
             self.load_uri(docset.index_file_path.as_uri())
         else:
             new_page = NewPage()
-            new_page.bind_property("title", self, "title", GObject.BindingFlags.DEFAULT)
-            self.set_child(NewPage())
+            # new_page.bind_property("title", self, "title", GObject.BindingFlags.DEFAULT)
+            self.set_child(new_page)
 
         self.web_view.bind_property(
             "estimated-load-progress",

--- a/docoloco/window/main.py
+++ b/docoloco/window/main.py
@@ -133,6 +133,7 @@ class MainWindow(Adw.ApplicationWindow):
             page = self.tab_view.append(doc_page)
 
         doc_page.bind_property("title", page, "title", GObject.BindingFlags.DEFAULT)
+        page.set_title(doc_page.title)
         page.connect("notify::title", self.on_page_title_changed)
         page.set_live_thumbnail(True)
         self.tab_view.set_selected_page(page)

--- a/docoloco/window/new_page.py
+++ b/docoloco/window/new_page.py
@@ -23,7 +23,7 @@ class NewPage(Adw.Bin):
         super().__init__()
 
         providers_list_page = ProvidersListPage(
-            get_registry().providers, self.open_provider_page
+            providers=get_registry().providers, on_activate_row=self.open_provider_page
         )
         self.navigation_view.add(providers_list_page)
 
@@ -44,7 +44,7 @@ class NewPage(Adw.Bin):
 
     def open_provider_page(self, provider: DocumentationProvider):
         provider_docs_page = ProviderPage(
-            provider, lambda _: self.navigation_view.pop()
+            provider, lambda: self.navigation_view.pop()
         )
 
         self.navigation_view.push(provider_docs_page)

--- a/docoloco/window/new_page.py
+++ b/docoloco/window/new_page.py
@@ -11,16 +11,13 @@ from .providers_list_page import ProvidersListPage
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 gi.require_version("WebKit", "6.0")
-from gi.repository import Adw, Gtk, GObject  # noqa: E402
+from gi.repository import Adw, Gtk  # noqa: E402
 
 
 @Gtk.Template(filename=default_config.ui("new_page"))
 class NewPage(Adw.Bin):
     __gtype_name__ = "NewPage"
     navigation_view = cast(Adw.NavigationView, Gtk.Template.Child())
-    title = GObject.Property(
-        type=str, flags=GObject.ParamFlags.READWRITE
-    )
 
     def __init__(self):
         super().__init__()
@@ -34,7 +31,7 @@ class NewPage(Adw.Bin):
         page = self.navigation_view.get_visible_page()
         if not isinstance(page, ProviderPage):
             return
-        
+
         title = title.strip().lower()
 
         def filter_func(box: Gtk.FlowBoxChild, *args):
@@ -46,6 +43,8 @@ class NewPage(Adw.Bin):
         provider_docs_page.filter_or_find(title, filter_func)
 
     def open_provider_page(self, provider: DocumentationProvider):
-        provider_docs_page = ProviderPage(provider, lambda _: self.navigation_view.pop())
+        provider_docs_page = ProviderPage(
+            provider, lambda _: self.navigation_view.pop()
+        )
 
         self.navigation_view.push(provider_docs_page)

--- a/docoloco/window/provider_page.py
+++ b/docoloco/window/provider_page.py
@@ -1,4 +1,3 @@
-from turtle import position
 from typing import Callable, cast
 
 import gi
@@ -45,7 +44,8 @@ class ProviderPage(Adw.NavigationPage):
 
             self.build_query_results_section()
 
-        self.back_btn.connect("activate", lambda _: print("yes"))  # TODO: Quite frankly do not know why this callback does not work..
+        self.back_btn.connect("activate", self.on_click_back) 
+        self.back_btn.connect("clicked", self.on_click_back, on_back_callback) # 'activate' does not work...
 
     def create_status_page(self):
         self.status_page = Adw.StatusPage()
@@ -114,9 +114,9 @@ class ProviderPage(Adw.NavigationPage):
         action_params = GLib.Variant("(ssi)", (self.provider.name, doc.name, pos))
         self.activate_action("win.change_docset", action_params)
 
-
-    def on_click_back(self, *args):
-        pass
+    def on_click_back(self, button, callback: Callable[[None], None] = None):
+        if callback:
+            callback()
 
     def _on_query_list_model_items_changed(self, model: Gio.ListStore, *args):
         if model.get_n_items() == 0:

--- a/docoloco/window/providers_list_page.py
+++ b/docoloco/window/providers_list_page.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, cast
+from typing import Callable, Dict, cast
 
 import gi
 


### PR DESCRIPTION
- Allow links to be opened in a new tab
- Fix bugs where navigation from the provider page to the providers list was not possible, and the title was not displaying on new tabs